### PR TITLE
fix the spatial: convention description to match the spec

### DIFF
--- a/src/geozarr_toolkit/conventions/spatial.py
+++ b/src/geozarr_toolkit/conventions/spatial.py
@@ -32,7 +32,7 @@ class SpatialConventionMetadata(ZarrConventionMetadata):
     name: Literal["spatial:"] = "spatial:"
     schema_url: str = SPATIAL_SCHEMA_URL
     spec_url: str = SPATIAL_SPEC_URL
-    description: str = "Spatial coordinate and transformation information"
+    description: str = "Spatial coordinate information"
 
 
 class Spatial(BaseModel):


### PR DESCRIPTION
In https://github.com/zarr-conventions/spatial/?tab=readme-ov-file#convention-registration and the zarr-validator (which is a fantastic resource as I develop [tessera-zarr](https://geotessera.org)!) the description for spatial is 

"Spatial coordinate information"

This PR changes the zarr-toolkit generation function to output this so the validator passes