### PR TITLE
Allow default values to be `None` (missing) for spatial convention

### DIFF
--- a/src/geozarr_toolkit/conventions/spatial.py
+++ b/src/geozarr_toolkit/conventions/spatial.py
@@ -62,10 +62,10 @@ class Spatial(BaseModel):
 
     dimensions: list[str] = Field(alias="spatial:dimensions")
     bbox: list[float] | None = Field(None, alias="spatial:bbox", exclude_if=is_none)
-    transform_type: str = Field("affine", alias="spatial:transform_type")
+    transform_type: str | None = Field(None, alias="spatial:transform_type", exclude_if=is_none)
     transform: list[float] | None = Field(None, alias="spatial:transform", exclude_if=is_none)
     shape: list[int] | None = Field(None, alias="spatial:shape", exclude_if=is_none)
-    registration: str = Field("pixel", alias="spatial:registration")
+    registration: str | None = Field(None, alias="spatial:registration", exclude_if=is_none)
 
     model_config = {"extra": "allow", "populate_by_name": True, "serialize_by_alias": True}
 


### PR DESCRIPTION
Since the spec explicitly allows for `transform_type` and `registration` to be missing, it seems like we should allow that as well in the toolkit. Currently, there's no way for the user to create missing keys.

This changes the default values of `transform_type` and `registration` to be `None`, in line with the defaults in the spec.

(For the record, I would be happy to be explicit in the spec that `transform_type: "affine"` must be set and that `registration: "pixel"` must be set, but that would be a backwards incompatible change)