### PR TITLE
Remove array-level spatial:bbox from with_transform fixture

### DIFF
--- a/tests/_test_data/spatial_examples/with_transform.json
+++ b/tests/_test_data/spatial_examples/with_transform.json
@@ -7,6 +7,5 @@
   ],
   "spatial:dimensions": ["Y", "X"],
   "spatial:transform": [10.0, 0.0, 500000.0, 0.0, -10.0, 5000000.0],
-  "spatial:shape": [1000, 1000],
-  "spatial:bbox": [500000.0, 4990000.0, 510000.0, 5000000.0]
+  "spatial:shape": [1000, 1000]
 }


### PR DESCRIPTION
## Summary

- Removes the array-level `spatial:bbox` line from `tests/_test_data/spatial_examples/with_transform.json`. The fixture pairs `spatial:bbox` with `spatial:transform` on the same array; that dual-source pattern is being disallowed by the convention.
- `spatial:transform` + `spatial:shape` remain authoritative. The bbox is fully derivable as the axis-aligned min/max over the four transformed grid corners.

Companion to the RFC at zarr-conventions/spatial#32 and the spec PR at zarr-conventions/spatial#31.

## Why

Floating-point divergence between a stored bbox and a stored transform creates an ambiguity the spec can't adjudicate (zarr-conventions/spatial#6). The new rule is: affine arrays carry `spatial:transform`, not `spatial:bbox`. This fixture is one of two example files in the GeoZarr ecosystem that demonstrates the now-forbidden pattern.

## Test plan

- [x] `test_spatial_from_fixture` in `tests/test_conventions/test_spatial.py` parametrizes over all `spatial_examples/*.json` and asserts only on `dimensions`. The change is safe under the existing suite.
- [x] No other test file references this fixture by name.
- [ ] Reviewer to run `pytest tests/test_conventions/test_spatial.py -v` locally.

## Follow-up

The `Spatial` pydantic model in `src/geozarr_toolkit/conventions/spatial.py` still permits `spatial:bbox` alongside `spatial:transform` at the array level. Tightening the model to enforce the new rule is a separate change, naturally sequenced after the upstream spec PR merges.
